### PR TITLE
beesh: convert EXCLUDE and BEE_AUTO_EXCLUDE to arrays

### DIFF
--- a/conf/templates/fallback
+++ b/conf/templates/fallback
@@ -8,7 +8,7 @@ PATCHURL[0]=""
 
 @BEE_BUILDTYPE@
 
-# EXCLUDE=""
+# EXCLUDE=()
 
 # build_in_sourcedir
 

--- a/manpages/beesh.1.in
+++ b/manpages/beesh.1.in
@@ -35,7 +35,7 @@ To exclude files use
 and provide a quoted 'space' separated list of regular expressions.
 .P
 .RS
-EXCLUDE="^/usr/share/gtk-doc ^/usr/share/doc"
+EXCLUDE=( ^/usr/share/gtk-doc ^/usr/share/doc )
 .RE
 .SS "Argh! My build takes so much time.."
 You might discover that

--- a/src/beelib.config.sh.in
+++ b/src/beelib.config.sh.in
@@ -23,6 +23,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+: ${BEE_BINDIR:=@BINDIR@}
+
 function config_init_colors() {
     if [ -t 1 ] ; then
         COLOR_NORMAL="\\033[0;39m\\033[0;22m"
@@ -153,6 +155,13 @@ function config_handle_deprecated_config() {
     deprecated_mv "BEE_PKGDIR"            "${BEE_REPOSITORY_PREFIX}/pkgs" "${BEE_PKGDIR}"
     deprecated_mv "BEE_DOWNLOADDIR"       "${BEE_REPOSITORY_PREFIX}/downloads" "${BEE_DOWNLOADDIR}"
     deprecated_mv "BEE_TMP_BUILDROOT"     "${BEE_TMP_TMPDIR}/beeroot-${USER}" "${BEE_TMP_BUILDROOT}"
+}
+
+function config_handle_deprecated_beefile() {
+    if [ -n "${EXCLUDE}" ] && [[ "$(declare -p EXCLUDE)" =~ 'EXCLUDE="' ]] ; then
+        print_warning "WARNING ${BEE##*/}: scalar usage of EXCLUDE is deprecated - converting it to an array.."
+        EXCLUDE=( ${EXCLUDE} )
+    fi
 }
 
 # load config: (bee/beerc)
@@ -328,10 +337,12 @@ function expand_prefix_variables() {
                SHAREDSTATEDIR LOCALSTATEDIR LIBDIR INCLUDEDIR \
                DATAROOTDIR DATADIR INFODIR LOCALEDIR MANDIR DOCDIR ; do
         eval eval ${var}=\${${var}}
-        eval 'BEE_AUTO_EXCLUDE="${BEE_AUTO_EXCLUDE} \${${var}}"'
+        eval 'BEE_AUTO_EXCLUDE=( "${BEE_AUTO_EXCLUDE[@]}" \${${var}} )'
     done
 
-    eval "BEE_AUTO_EXCLUDE=\"${BEE_AUTO_EXCLUDE}\""
+    eval "BEE_AUTO_EXCLUDE=( ${BEE_AUTO_EXCLUDE[@]} )"
+
+    BEE_AUTO_EXCLUDE=( $(${BEE_BINDIR}/beecut -d '/' -p '^' -a '$' -n "${BEE_AUTO_EXCLUDE[@]}" | sort -u) )
 }
 
 function config_init() {

--- a/src/beesh.sh.in
+++ b/src/beesh.sh.in
@@ -431,15 +431,14 @@ function bee_crosscheck() {
 # $EXCLUDE is read from .bee file
 # $BEE_SKIPLIST is found in $BEEFAULTS
 function bee_pkg_pack() {
-
-    aex=$(${BEE_BINDIR}/beecut -d '/' -p '^' -a '$' -n ${BEE_AUTO_EXCLUDE} | sort -u)
-
-    for e in ${EXCLUDE} ${aex} ; do
-        exargs="${exargs} --exclude=${e}";
-    done
-
-    beefind.pl ${BEE_SKIPLIST:+--excludelist=${BEE_SKIPLIST}} \
-               --exclude='^/FILES$' ${exargs} \
+    beefind.pl --exclude='^/FILES$' \
+               --excludelist=<(
+                   if [ -n "${BEE_SKIPLIST}" ] ; then
+                       cat ${BEE_SKIPLIST}
+                   fi
+                   for pattern in "${EXCLUDE[@]}" "${BEE_AUTO_EXCLUDE[@]}" ; do
+                      echo "${pattern}"
+                   done ) \
                --cutroot=${D} ${D} > ${D}/FILES 2>/dev/null
 
     DUMP=${BEE_TMP_TMPDIR}/bee.$$.dump
@@ -746,6 +745,7 @@ PKGALLPKG=
 # since PKGARCH is now known reconstruct PKGALLPKG
 : ${PKGALLPKG:=${PKGFULLPKG}.${PKGARCH}}
 
+config_handle_deprecated_beefile
 expand_prefix_variables
 
 ###############################################################################


### PR DESCRIPTION
A deprecation warning will be issued if EXCLUDE is still used in scalar context.

this fixes issue #64

please review and comment... thx
