### PR TITLE
beelib: export BEE_BINDIR

### DIFF
--- a/src/beelib.config.sh.in
+++ b/src/beelib.config.sh.in
@@ -366,6 +366,7 @@ function config_export() {
     export BEE_TMP_TMPDIR
     export BEE_TMP_BUILDROOT
 
+    export BEE_BINDIR
     export BEE_SYSCONFDIR
     export BEE_DATADIR
     export BEE_LIBEXECDIR


### PR DESCRIPTION
lines like
: ${BEE_BINDIR:=@BINDIR@}
will become redundant
