### PR TITLE
beesh: Fix use of bee_buildmagic variable

### DIFF
--- a/src/beesh.sh.in
+++ b/src/beesh.sh.in
@@ -1022,7 +1022,7 @@ cd "${S}"
 
 bee_run patch "${bee_PATCHFILES[@]}"
 
-bee_buildmagic=$("${BEE_BINDIR}/beeuniq" "${BEE_BUILDTYPE[@]}" \
+bee_buildmagic=( $("${BEE_BINDIR}/beeuniq" "${BEE_BUILDTYPE[@]}" \
                                cmake \
                                autotools \
                                autogen \
@@ -1032,7 +1032,7 @@ bee_buildmagic=$("${BEE_BINDIR}/beeuniq" "${BEE_BUILDTYPE[@]}" \
                                make \
                                jb \
                                haskell-module \
-                               )
+                               ) )
 
 BEE_BUILDTYPE_DETECTED=""
 


### PR DESCRIPTION
Turn variable `bee_buildmagic` to an array.