### PR TITLE
Gitify

### DIFF
--- a/conf/templates/fallback
+++ b/conf/templates/fallback
@@ -3,6 +3,16 @@
 ## this file was created by bee init and should be executed to build a
 ## bee-package. (Additional hints are located at the end of this file.)
 
+##########################
+## Set version information from within beefile by adding/uncommenting
+## these lines (requires bee >= 1.3):
+##
+## #@beepackage pkgname-version-revision
+## require_version 1.3
+
+##@beepackage @PKGALLPKG@
+#require_version 1.2.99
+
 ###############################################################################
 ## The source URL(s) define the location of the sources that will be
 ## downloaded. Version variables may be used to simplify reuse of this bee-file.

--- a/src/bee-init.sh.in
+++ b/src/bee-init.sh.in
@@ -344,6 +344,9 @@ function initialize() {
             -i ${beefile}
     fi
 
+    sed -e "s,@PKGALLPKG@,${PKGALLPKG}," \
+        -i ${beefile}
+
     bee_versionify ${beefile}
 
     chmod 755 ${beefile}

--- a/src/bee-init.sh.in
+++ b/src/bee-init.sh.in
@@ -120,10 +120,10 @@ function bee_versionify() {
 
     i=${#PKGVERSION[@]}-2
 
-    rules="-e 's,${PKGVERSION//\./\\.},\${PKGVERSION},g'"
+    rules="-e '/SRCURL/s,${PKGVERSION//\./\\.},\${PKGVERSION},g'"
 
     while [ $i -gt 1 ] ; do
-       rules="${rules} -e 's,${PKGVERSION[$i]//\./\\.},\${PKGVERSION[$i]},g'"
+       rules="${rules} -e '/SRCURL/s,${PKGVERSION[$i]//\./\\.},\${PKGVERSION[$i]},g'"
 
        i=i-1
     done
@@ -290,7 +290,7 @@ function initialize() {
 
     create_beefile_from_template ${beefile} ${TEMPLATE}
 
-    sed -e "s,@SRCURL@,SRCURL[0]=\"${surl}\"," \
+    sed -e "s,@SRCURL@,SRCURL=( \"${surl}\" )," \
         -i ${beefile}
 
     if [ -z "${DEFAULT_CONFIGURE_OPTIONS}" ] ; then

--- a/src/beesh.sh.in
+++ b/src/beesh.sh.in
@@ -141,17 +141,11 @@ function check_rebuild() {
         return 0
     fi
 
-    beefile_dir=${beefile%/*}
     eval $(${BEEVERSION} "${beefile}")
 
     beefile_pattern="${PKGFULLNAME}-${PKGFULLVERSION}"
-    beefile_pattern=${beefile_pattern//+/\\+} # replace all + with \+
-    beefile_pattern=${beefile_pattern//./\\.} # replace all . with \.
-
-    beefile_max=$(for bf in $(ls ${beefile%/*}/${beefile_pattern}*.bee ${BEE_BEEDIR}/${beefile_pattern}*.bee 2>/dev/null |\
-                              grep -E "/${beefile_pattern}-[0-9]+.bee") ; do
-                      echo "${bf}"
-                  done | ${BEESORT} | tail -1)
+    shopt -s extglob
+    beefile_max=$( ls "${beefile%/*}/${beefile_pattern}"-+([0-9]).bee "${BEE_BEEDIR}/${beefile_pattern}"-+([0-9]).bee 2>/dev/null | ${BEESORT} | tail -1)
 
     eval $(${BEEVERSION} ${beefile_max})
     print_warning "please increase revision number to $((PKGREVISION + 1))"

--- a/src/beesh.sh.in
+++ b/src/beesh.sh.in
@@ -592,8 +592,6 @@ function bee_crosscheck() {
 
 #### bee_pkg_pack() ###########################################################
 
-# $EXCLUDE is read from .bee file
-# $BEE_SKIPLIST is found in $BEEFAULTS
 function bee_pkg_pack() {
     ${BEEFIND} --exclude='^/CONTENT$' \
                --exclude-list=<(
@@ -938,7 +936,7 @@ print_info "  BEE_TMP_BUILDROOT      ${BEE_TMP_BUILDROOT}"
 
 BEE=$1
 if [ "${BEE:0:1}" != "/" ] ; then
-    BEE=${PWD}/$BEE
+    BEE=${PWD}/${BEE}
 fi
 
 if [ ! -f "${BEE}" ] ; then

--- a/src/beesh.sh.in
+++ b/src/beesh.sh.in
@@ -141,8 +141,6 @@ function check_rebuild() {
         return 0
     fi
 
-    print_warning "please increase revision number"
-
     beefile_dir=${beefile%/*}
     eval $(${BEEVERSION} "${beefile}")
 
@@ -150,13 +148,13 @@ function check_rebuild() {
     beefile_pattern=${beefile_pattern//+/\\+} # replace all + with \+
     beefile_pattern=${beefile_pattern//./\\.} # replace all . with \.
 
-    beefile_max=$(for bf in $(ls "${beefile%/*}/${beefile_pattern}*.bee" "${BEE_BEEDIR}/${beefile_pattern}*.bee" 2>/dev/null |\
+    beefile_max=$(for bf in $(ls ${beefile%/*}/${beefile_pattern}*.bee ${BEE_BEEDIR}/${beefile_pattern}*.bee 2>/dev/null |\
                               grep -E "/${beefile_pattern}-[0-9]+.bee") ; do
                       echo "${bf}"
                   done | ${BEESORT} | tail -1)
 
     eval $(${BEEVERSION} ${beefile_max})
-    print_warning "cp ${beefile} ${PWD}/${PKGFULLNAME}-${PKGFULLVERSION}-$((PKGREVISION + 1)).bee"
+    print_warning "please increase revision number to $((PKGREVISION + 1))"
 
     exit 1
 }
@@ -949,7 +947,33 @@ PKGNAME=
 PKGVERSION=
 PKGREVISION=
 
-eval $("${BEE_BINDIR}/beeversion" "${BEE}")
+set +e
+
+BEEOVERWRITE=( $(grep -m 1 '^#@beepackage' "${BEE}") )
+if [ $? == 0 ] ; then
+    ver=${BEEOVERWRITE[1]}
+    overwrite=1
+else
+    ver=${BEE}
+    overwrite=0
+fi
+
+set -e
+
+eval $("${BEEVERSION}" "${ver}")
+
+if [ "${overwrite}" == 1 ] ; then
+    if [ "${BEE##*/}" == "${PKGNAME}.bee" ] ; then
+        :
+    elif [ "${BEE##*/}" == "${PKGFULLNAME}.bee" ] ; then
+        :
+    elif [ "${BEE##*/}" == "${PKGFULLPKG}.bee" ] ; then
+        print_warning "***ATTENTION***: using full beefile name (including version) and the #@beepackage feature at the same time."
+    else
+        print_error "filename '${BEE##*/}' does not match '${BEEOVERWRITE[1]}' set as #@beepackage for PKGNAME or PKGFULLNAME"
+        exit 1
+    fi
+fi
 
 if [ -z "${PKGNAME}" -o -z "${PKGVERSION}" -o -z "${PKGREVISION}" ] ; then
     print_error "${BEE}: please use the proper package versioning (e.g. package-1.0-0)"
@@ -986,7 +1010,7 @@ config_export
 
 ###############################################################################
 
-check_rebuild "${BEE}" "${PKGALLPKG}"
+check_rebuild "${BEE%/*}/${PKGFULLPKG}.bee" "${PKGALLPKG}"
 
 print_info "current working directory: ${PWD}"
 


### PR DESCRIPTION
beesh: Enable versionless bee filenames by setting #@beepackage in beefile

use '#@beepackage pkg-1.0-0' to set version information within bee file.

the bee file needs to match <PKGNAME>.bee or <PKGFULLNAME>.bee

This enables bee-files to be stored in git repositories and track changes.