### PR TITLE
beeversion: Fix output of %X[ex] when X is not dash or underscore

### DIFF
--- a/src/bee_version_output.c
+++ b/src/bee_version_output.c
@@ -143,14 +143,16 @@ void print_format(char* s, struct beeversion *v, char *filter_pkgfullname)
                         if (*(v->subname))
                             printf("%c%s", *p, v->subname);
                         p++;
-                        break;
+                        continue;
                     case 'e':
                         if (*(v->extraversion))
                             printf("%c%s", *p, v->extraversion);
                         p++;
-                        break;
+                        continue;
                   }
-                  break;
+                default:
+                    printf("%%%c", *p);
+                    break;
             }
             continue;
         } /* if '%' */
@@ -168,6 +170,9 @@ void print_format(char* s, struct beeversion *v, char *filter_pkgfullname)
                     break;
                 case 'E':
                     cut_and_print(v->extraversion, '_', 1);
+                    break;
+                default:
+                    printf("@%c", *p);
                     break;
             }
             continue;

--- a/src/bee_version_output.c
+++ b/src/bee_version_output.c
@@ -136,20 +136,21 @@ void print_format(char* s, struct beeversion *v, char *filter_pkgfullname)
                     if(*p == 'A' && *(v->arch))
                         printf(".%s", v->arch);
                     break;
-            }
-            if (*p) {
-                switch(*(p+1)) {
+                case '-':
+                case '_':
+                  switch(*(p+1)) {
                     case 'x':
                         if (*(v->subname))
                             printf("%c%s", *p, v->subname);
                         p++;
-                        continue;
+                        break;
                     case 'e':
                         if (*(v->extraversion))
                             printf("%c%s", *p, v->extraversion);
                         p++;
-                        continue;
-                }
+                        break;
+                  }
+                  break;
             }
             continue;
         } /* if '%' */
@@ -194,4 +195,3 @@ void print_format(char* s, struct beeversion *v, char *filter_pkgfullname)
 
     } /* for *p */
 }
-


### PR DESCRIPTION
Enforce only prefixing dash or underscore chars when printing
extra{version,name} in %[-_][ex] format strings

fixes https://github.com/bee/bee/issues/207