### PR TITLE
beesh: restore feature to overwrite filename

### DIFF
--- a/src/beesh.sh.in
+++ b/src/beesh.sh.in
@@ -323,17 +323,21 @@ function fetch_one_patch() {
 
 function bee_getsrcurl() {
     local -a archives=( "${@}" )
+    local url filename
 
     for a in "${archives[@]}" ; do
-        fetch_one_archive "${a}"
+        read -r url filename <<< "${a}"
+        fetch_one_archive "${url}" "${filename}"
     done
 }
 
 function bee_getpatchurl() {
     local -a patches=( "${@}" )
+    local url filename
 
     for p in "${patches[@]}" ; do
-        fetch_one_patch "${p}"
+        read -r url filename <<< "${p}"
+        fetch_one_patch "${url}" "${filename}"
     done
 }
 


### PR DESCRIPTION
With 4c248a4 (beesh: more quoting) we've lost the ability to specify
a local filename after the URL in SRCURL and PATCHURL. This is usefull
when the URL doesn't end in a usable filename. E.g.

  SRCURL[0]="https://foo.bar.de/foobar-3.2?format=tgz foobar-3.2.tgz"
or
  PATCHURL+=("https://foo.bar.de/get_patch?0d223385b9 0d223385b9.patch")

This patch restores the feature but avoids globbing and other shell
interpretation at the same time. The split at whitespace is no problem,
because whitespace needs to be URL-encoded anyway.