### PR TITLE
Support Meson build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ BUILDTYPES+=cmake
 BUILDTYPES+=configure
 BUILDTYPES+=jb
 BUILDTYPES+=make
+BUILDTYPES+=meson
 BUILDTYPES+=perl-module
 BUILDTYPES+=perl-module-makemaker
 BUILDTYPES+=python-module

--- a/buildtypes/meson.sh.in
+++ b/buildtypes/meson.sh.in
@@ -1,0 +1,59 @@
+#
+# bee magic for meson
+#
+# Copyright (C) 2017
+#       Paul Menzel <pmenzel@molgen.mpg.de>
+#       and other bee developers
+#
+# This file is part of bee.
+#
+# bee is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+: ${BEE_BUILDTYPE_MESON_MESONBUILD:=${S}/meson.build}
+
+if [ ! -r "${BEE_BUILDTYPE_MESON_MESONBUILD}" ] ; then
+    return
+fi
+
+if ! type -p meson >/dev/null 2>&1 ; then
+    return
+fi
+
+BEE_BUILDTYPE_DETECTED=meson
+
+BEE_BUILDTYPE_MESON_SOURCEDIR=${BEE_BUILDTYPE_MESON_MESONBUILD%/*}
+
+#### bee_configure() ##########################################################
+
+bee_configure() {
+    start_cmd meson \
+        --prefix ${PREFIX} \
+        --buildtype=plain \
+        "${@}" \
+        ${S}
+}
+
+#### bee_build() ##############################################################
+
+bee_build() {
+    start_cmd ninja -v -C ${B} ${BEE_MAKEFLAGS} "${@}"
+}
+
+#### bee_install() ############################################################
+
+bee_install() {
+    start_cmd DESTDIR=${D} ninja -C ${B} install "${@}"
+}
+

--- a/buildtypes/meson.sh.in
+++ b/buildtypes/meson.sh.in
@@ -27,10 +27,6 @@ if [ ! -r "${BEE_BUILDTYPE_MESON_MESONBUILD}" ] ; then
     return
 fi
 
-if ! type -p meson >/dev/null 2>&1 ; then
-    return
-fi
-
 BEE_BUILDTYPE_DETECTED=meson
 
 BEE_BUILDTYPE_MESON_SOURCEDIR=${BEE_BUILDTYPE_MESON_MESONBUILD%/*}

--- a/src/beesh.sh.in
+++ b/src/beesh.sh.in
@@ -1054,6 +1054,7 @@ bee_run patch "${bee_PATCHFILES[@]}"
 
 bee_buildmagic=( $("${BEE_BINDIR}/beeuniq" "${BEE_BUILDTYPE[@]}" \
                                cmake \
+                               meson \
                                autotools \
                                autogen \
                                perl-module \


### PR DESCRIPTION
In MarIuX, make sure to have Meson installed, for example, by doing `. /pkg/python-3.6.4-0/profile`.
  