### PR TITLE
perl-modules: Fix quoting

### DIFF
--- a/buildtypes/perl-module-makemaker.sh.in
+++ b/buildtypes/perl-module-makemaker.sh.in
@@ -53,5 +53,5 @@ bee_install() {
     start_cmd make ${BEE_MAKEFLAGS} \
         install \
         "${@}"
-    find ${D} -name perllocal.pod -exec rm {} \;
+    find "${D}" -name perllocal.pod -exec rm {} \;
 }

--- a/buildtypes/perl-module.sh.in
+++ b/buildtypes/perl-module.sh.in
@@ -53,5 +53,5 @@ bee_install() {
     start_cmd ./Build \
         install \
         "${@}"
-    find ${D} -name perllocal.pod -exec rm {} \;
+    find "${D}" -name perllocal.pod -exec rm {} \;
 }


### PR DESCRIPTION
As @ruester pointed out in bee/bee#213, ${D} should be quoted when used.

Add quotes.